### PR TITLE
AR15 Draggable Courses now have a Description

### DIFF
--- a/academic-requirements/src/components/DraggableCourse.tsx
+++ b/academic-requirements/src/components/DraggableCourse.tsx
@@ -3,6 +3,7 @@ import { memo } from "react";
 import { useDrag } from "react-dnd";
 import React from "react";
 import "./DraggableCourse.css";
+import { func } from "prop-types";
 
 //defines the expected course properties
 export interface CourseProps {
@@ -46,6 +47,18 @@ export const Course: FC<CourseProps> = memo(function Course({
     }),
     [name, type, dragSource] //what is collected by the semester and course list when you drop it
   );
+
+  // Gets the URL to the UW Stout Bulletin for the given Course
+  function getURL(subject, number) {
+    var URL =
+      "https://bulletin.uwstout.edu/content.php?filter%5B27%5D=" +
+      subject +
+      "&filter%5B29%5D=" +
+      number +
+      "&filter%5Bcourse_type%5D=-1&filter%5Bkeyword%5D=&filter%5B32%5D=1&filter%5Bcpage%5D=1&cur_cat_oid=21&expand=&navoid=544&search_database=Filter#acalog_template_course_filter";
+    return URL;
+  }
+
   return (
     <div
       ref={drag}
@@ -59,6 +72,10 @@ export const Course: FC<CourseProps> = memo(function Course({
       {name}
       <br />
       credits: {credits}
+      <br />
+      <a href={getURL(subject, number)} target="_blank">
+        Description
+      </a>
     </div>
   );
 });


### PR DESCRIPTION
[AR-15 Draggable Courses now have a Description link](https://academic-cs458.atlassian.net/browse/AR-15)

The Draggable Courses when creating the Semester page now has a Description Link that links to the UW Stout Bulletin page with the course description.

@ruudkas
@ChrisVasterling
@Tyler-Pamperin